### PR TITLE
Run tests before build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: run tests
-        run: npm test
+      - name: Run production tests
+        run: npm run test:production

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  resetMocks: true,
+  moduleNameMapper: {
+    "^@sdgindex/data(.*)$": "<rootDir>/src$1",
+    "^mock:@sdgindex/data(.*)$": "<rootDir>/src$1",
+    "^testHelpers(.*)$": "<rootDir>/tests/helpers$1",
+  },
+};

--- a/jest.production.config.js
+++ b/jest.production.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  resetMocks: true,
+  moduleNameMapper: {
+    "^@sdgindex/data(.*)$": "<rootDir>$1",
+    "^mock:@sdgindex/data(.*)$": "<rootDir>/cjs$1",
+    "^testHelpers(.*)$": "<rootDir>/tests/helpers$1",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "npm run build:cjs && npm run build:es",
     "build:cjs": "trash cjs/* && cross-env NODE_ENV=cjs babel src --out-dir cjs",
     "build:es": "trash es/* && cross-env NODE_ENV=es babel src --out-dir es",
-    "test": "jest",
+    "test": "jest --config=jest.config.js",
+    "test:production": "jest --config=jest.production.config.js",
     "docs": "npx esdoc",
     "prepare": "npm run build && husky install",
     "release": "np"
@@ -31,13 +32,6 @@
     "cjs",
     "es"
   ],
-  "jest": {
-    "moduleNameMapper": {
-      "@root(.*)$": "<rootDir>/$1",
-      "testHelpers(.*)$": "<rootDir>/tests/helpers/$1"
-    },
-    "resetMocks": true
-  },
   "devDependencies": {
     "@babel/cli": "^7.12.16",
     "@babel/core": "^7.14.0",

--- a/tests/assessments/isGlobalOnly.test.js
+++ b/tests/assessments/isGlobalOnly.test.js
@@ -1,4 +1,4 @@
-import { isGlobalOnly } from "@root/assessments";
+import { isGlobalOnly } from "@sdgindex/data/assessments";
 import { buildIndicator } from "testHelpers/builders";
 
 it("returns true if the indicator is global only", () => {

--- a/tests/assessments/isGoal.test.js
+++ b/tests/assessments/isGoal.test.js
@@ -1,4 +1,4 @@
-import { isGoal } from "@root/assessments";
+import { isGoal } from "@sdgindex/data/assessments";
 import { buildGoal, buildIndicator } from "testHelpers/builders";
 
 it("returns true if assessment is a goal", () => {

--- a/tests/assessments/isIndicator.test.js
+++ b/tests/assessments/isIndicator.test.js
@@ -1,4 +1,4 @@
-import { isIndicator } from "@root/assessments";
+import { isIndicator } from "@sdgindex/data/assessments";
 import { buildGoal, buildIndicator } from "testHelpers/builders";
 
 it("returns true if assessment is an indicator", () => {

--- a/tests/assessments/isOecdOnly.test.js
+++ b/tests/assessments/isOecdOnly.test.js
@@ -1,4 +1,4 @@
-import { isOecdOnly } from "@root/assessments";
+import { isOecdOnly } from "@sdgindex/data/assessments";
 import { buildIndicator } from "testHelpers/builders";
 
 it("returns true if the indicator is OECD only", () => {

--- a/tests/assessments/isOverallAssessment.test.js
+++ b/tests/assessments/isOverallAssessment.test.js
@@ -1,4 +1,4 @@
-import { isOverallAssessment } from "@root/assessments";
+import { isOverallAssessment } from "@sdgindex/data/assessments";
 import { buildGoal, buildOverallAssessment } from "testHelpers/builders";
 
 it("returns true if assessment is overall SDG assessment", () => {

--- a/tests/assessments/isRelevantIndicatorForRegion.test.js
+++ b/tests/assessments/isRelevantIndicatorForRegion.test.js
@@ -1,4 +1,4 @@
-import { isRelevantIndicatorForRegion } from "@root/assessments";
+import { isRelevantIndicatorForRegion } from "@sdgindex/data/assessments";
 import { buildIndicator, buildRegion } from "testHelpers/builders";
 
 describe("when region is an OECD country", () => {

--- a/tests/assessments/isSpilloverAssessment.test.js
+++ b/tests/assessments/isSpilloverAssessment.test.js
@@ -1,4 +1,4 @@
-import { isSpilloverAssessment } from "@root/assessments";
+import { isSpilloverAssessment } from "@sdgindex/data/assessments";
 import {
   buildOverallAssessment,
   buildSpilloverAssessment,

--- a/tests/assessments/isTrendIndicator.test.js
+++ b/tests/assessments/isTrendIndicator.test.js
@@ -1,4 +1,4 @@
-import { isTrendIndicator } from "@root/assessments";
+import { isTrendIndicator } from "@sdgindex/data/assessments";
 import { buildIndicator } from "testHelpers/builders";
 
 it("returns true if the indicator is a trend indicator", () => {

--- a/tests/ensureDataIds.test.js
+++ b/tests/ensureDataIds.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { ensureDataIds } from "@root";
+import { ensureDataIds } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/findAssessmentById.test.js
+++ b/tests/findAssessmentById.test.js
@@ -1,4 +1,4 @@
-import { findAssessmentById } from "@root";
+import { findAssessmentById } from "@sdgindex/data";
 import { buildIndicator, buildIndicators } from "testHelpers/builders";
 
 it("finds assessment with ID indicator1", () => {

--- a/tests/findAssessmentBySlug.test.js
+++ b/tests/findAssessmentBySlug.test.js
@@ -1,4 +1,4 @@
-import { findAssessmentBySlug } from "@root";
+import { findAssessmentBySlug } from "@sdgindex/data";
 import { buildIndicator, buildIndicators } from "testHelpers/builders";
 
 it("finds assessment by slug SDG1_my_indicator", () => {

--- a/tests/findAssessmentForRegionById.test.js
+++ b/tests/findAssessmentForRegionById.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { findAssessmentForRegionById } from "@root";
+import { findAssessmentForRegionById } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/findGoalForRegionById.test.js
+++ b/tests/findGoalForRegionById.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { findAssessmentForRegionById } from "@root";
+import { findAssessmentForRegionById } from "@sdgindex/data";
 import {
   buildGoal,
   buildIndicators,

--- a/tests/findIndicatorById.test.js
+++ b/tests/findIndicatorById.test.js
@@ -1,4 +1,4 @@
-import { findIndicatorById } from "@root";
+import { findIndicatorById } from "@sdgindex/data";
 import { buildIndicator, buildIndicators } from "testHelpers/builders";
 
 it("finds indicator by id for SDG14_physics", () => {

--- a/tests/findIndicatorBySlug.test.js
+++ b/tests/findIndicatorBySlug.test.js
@@ -1,4 +1,4 @@
-import { findAssessmentBySlug } from "@root";
+import { findAssessmentBySlug } from "@sdgindex/data";
 import { buildIndicator, buildIndicators } from "testHelpers/builders";
 
 it("finds indicator by slug SDG1_my_indicator", () => {

--- a/tests/findIndicatorForRegionById.test.js
+++ b/tests/findIndicatorForRegionById.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { findIndicatorForRegionById } from "@root";
+import { findIndicatorForRegionById } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/findIndicatorForRegionBySlug.test.js
+++ b/tests/findIndicatorForRegionBySlug.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { findIndicatorForRegionBySlug } from "@root";
+import { findIndicatorForRegionBySlug } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/findObservationByRegionAndAssessment.test.js
+++ b/tests/findObservationByRegionAndAssessment.test.js
@@ -1,4 +1,4 @@
-import { findObservationByRegionAndAssessment } from "@root";
+import { findObservationByRegionAndAssessment } from "@sdgindex/data";
 import {
   buildIndicator,
   buildRegion,

--- a/tests/findRegionById.test.js
+++ b/tests/findRegionById.test.js
@@ -1,4 +1,4 @@
-import { findRegionById } from "@root";
+import { findRegionById } from "@sdgindex/data";
 import { buildRegion, buildRegions } from "testHelpers/builders";
 
 it("finds region with ID 'REGION_1'", () => {

--- a/tests/findRegionBySlug.test.js
+++ b/tests/findRegionBySlug.test.js
@@ -1,4 +1,4 @@
-import { findRegionBySlug } from "@root";
+import { findRegionBySlug } from "@sdgindex/data";
 import { buildRegion, buildRegions } from "testHelpers/builders";
 
 it("finds region with slug 'my-region'", () => {

--- a/tests/findRegionWithAssessmentById.test.js
+++ b/tests/findRegionWithAssessmentById.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { findRegionWithAssessmentById } from "@root";
+import { findRegionWithAssessmentById } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/findTimeseriesByRegionAndAssessment.test.js
+++ b/tests/findTimeseriesByRegionAndAssessment.test.js
@@ -1,4 +1,4 @@
-import { findTimeseriesByRegionAndAssessment } from "@root";
+import { findTimeseriesByRegionAndAssessment } from "@sdgindex/data";
 import {
   buildOverallAssessment,
   buildRegion,

--- a/tests/findTimeseriesByRegionAndIndicator.test.js
+++ b/tests/findTimeseriesByRegionAndIndicator.test.js
@@ -1,4 +1,4 @@
-import { findTimeseriesByRegionAndAssessment } from "@root";
+import { findTimeseriesByRegionAndAssessment } from "@sdgindex/data";
 import {
   buildIndicator,
   buildRegion,

--- a/tests/getGoals.test.js
+++ b/tests/getGoals.test.js
@@ -1,4 +1,4 @@
-import { getGoals } from "@root";
+import { getGoals } from "@sdgindex/data";
 import {
   buildIndicators,
   buildGoals,

--- a/tests/getGoalsForRegion.test.js
+++ b/tests/getGoalsForRegion.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { getGoalsForRegion } from "@root";
+import { getGoalsForRegion } from "@sdgindex/data";
 import {
   buildGoals,
   buildIndicator,

--- a/tests/getIndicators.test.js
+++ b/tests/getIndicators.test.js
@@ -1,4 +1,4 @@
-import { getIndicators } from "@root";
+import { getIndicators } from "@sdgindex/data";
 import {
   buildIndicators,
   buildGoals,

--- a/tests/getIndicatorsByGoal.test.js
+++ b/tests/getIndicatorsByGoal.test.js
@@ -1,4 +1,4 @@
-import { getIndicatorsByGoal } from "@root";
+import { getIndicatorsByGoal } from "@sdgindex/data";
 import {
   buildIndicators,
   buildGoal,

--- a/tests/getIndicatorsForRegion.test.js
+++ b/tests/getIndicatorsForRegion.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { getIndicatorsForRegion } from "@root";
+import { getIndicatorsForRegion } from "@sdgindex/data";
 import {
   buildGoals,
   buildIndicator,

--- a/tests/getIndicatorsForRegionByGoal.test.js
+++ b/tests/getIndicatorsForRegionByGoal.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { getIndicatorsForRegionByGoal } from "@root";
+import { getIndicatorsForRegionByGoal } from "@sdgindex/data";
 import {
   buildGoal,
   buildGoals,

--- a/tests/getObservationsForAssessment.test.js
+++ b/tests/getObservationsForAssessment.test.js
@@ -1,4 +1,4 @@
-import { getObservationsForAssessment } from "@root";
+import { getObservationsForAssessment } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/getObservationsForAssessmentFast.test.js
+++ b/tests/getObservationsForAssessmentFast.test.js
@@ -1,4 +1,4 @@
-import { getObservationsForAssessment } from "@root";
+import { getObservationsForAssessment } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/getOverallAssessment.test.js
+++ b/tests/getOverallAssessment.test.js
@@ -1,4 +1,4 @@
-import { getOverallAssessment } from "@root";
+import { getOverallAssessment } from "@sdgindex/data";
 import {
   buildIndicators,
   buildGoals,

--- a/tests/getOverallAssessmentForRegion.test.js
+++ b/tests/getOverallAssessmentForRegion.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { getOverallAssessmentForRegion } from "@root";
+import { getOverallAssessmentForRegion } from "@sdgindex/data";
 import {
   buildIndicators,
   buildGoals,

--- a/tests/getRegions.test.js
+++ b/tests/getRegions.test.js
@@ -1,4 +1,4 @@
-import { getRegions } from "@root";
+import { getRegions } from "@sdgindex/data";
 import { buildRegions } from "testHelpers/builders";
 
 const regions = buildRegions();

--- a/tests/getRegionsByType.test.js
+++ b/tests/getRegionsByType.test.js
@@ -1,4 +1,4 @@
-import { getRegionsByType } from "@root";
+import { getRegionsByType } from "@sdgindex/data";
 import { buildRegions } from "testHelpers/builders";
 
 const cities = buildRegions({ type: "city" });

--- a/tests/getRegionsWithAssessment.test.js
+++ b/tests/getRegionsWithAssessment.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { getRegionsWithAssessment } from "@root";
+import { getRegionsWithAssessment } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/getRegionsWithAssessmentFast.test.js
+++ b/tests/getRegionsWithAssessmentFast.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { getRegionsWithAssessmentFast } from "@root";
+import { getRegionsWithAssessmentFast } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/getRegionsWithTimeseries.test.js
+++ b/tests/getRegionsWithTimeseries.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { getRegionsWithTimeseries } from "@root";
+import { getRegionsWithTimeseries } from "@sdgindex/data";
 import {
   buildIndicator,
   buildIndicators,

--- a/tests/getSpilloverAssessment.test.js
+++ b/tests/getSpilloverAssessment.test.js
@@ -1,4 +1,4 @@
-import { getSpilloverAssessment } from "@root";
+import { getSpilloverAssessment } from "@sdgindex/data";
 import {
   buildIndicators,
   buildGoals,

--- a/tests/getSpilloverAssessmentForRegion.test.js
+++ b/tests/getSpilloverAssessmentForRegion.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { getSpilloverAssessmentForRegion } from "@root";
+import { getSpilloverAssessmentForRegion } from "@sdgindex/data";
 import {
   buildIndicators,
   buildGoals,

--- a/tests/getTrendIndicators.test.js
+++ b/tests/getTrendIndicators.test.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import { getTrendIndicators } from "@root";
+import { getTrendIndicators } from "@sdgindex/data";
 import {
   buildIndicators,
   buildGoals,

--- a/tests/helpers/builders.js
+++ b/tests/helpers/builders.js
@@ -1,6 +1,6 @@
 import faker from "faker";
 import { omit, random } from "lodash";
-import { START_YEAR, END_YEAR } from "@root/src/timeseries/config";
+import { START_YEAR, END_YEAR } from "../../src/timeseries/config";
 import renameKeys from "./renameKeys";
 
 // Ensures that all IDs, data IDs, and slugs are unique

--- a/tests/loadData.test.js
+++ b/tests/loadData.test.js
@@ -1,5 +1,5 @@
-import { loadData, loadDataset } from "@root";
-jest.mock("@root/cjs/loadDataset");
+import { loadData, loadDataset } from "@sdgindex/data";
+jest.mock("mock:@sdgindex/data/loadDataset");
 
 it("loads region, assessments, and observations into dataStore", () => {
   loadDataset.mockImplementation((dataStore, dataset) => {

--- a/tests/loadDataset.test.js
+++ b/tests/loadDataset.test.js
@@ -1,4 +1,4 @@
-import { loadDataset } from "@root";
+import { loadDataset } from "@sdgindex/data";
 
 beforeEach(() => {
   global.fetch = jest.fn().mockImplementation((url) => {

--- a/tests/loadTimeseries.test.js
+++ b/tests/loadTimeseries.test.js
@@ -1,5 +1,5 @@
-import { loadTimeseries, loadDataset } from "@root";
-jest.mock("@root/cjs/loadDataset");
+import { loadTimeseries, loadDataset } from "@sdgindex/data";
+jest.mock("mock:@sdgindex/data/loadDataset");
 
 it("loads timeseries into dataStore", () => {
   loadDataset.mockImplementation((dataStore, dataset) => {

--- a/tests/observations/getRank.test.js
+++ b/tests/observations/getRank.test.js
@@ -1,4 +1,4 @@
-import { getRank } from "@root/observations";
+import { getRank } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the numeric rank", () => {

--- a/tests/observations/getRankAsText.test.js
+++ b/tests/observations/getRankAsText.test.js
@@ -1,4 +1,4 @@
-import { getRankAsText } from "@root/observations";
+import { getRankAsText } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the rank as string", () => {

--- a/tests/observations/getRating.test.js
+++ b/tests/observations/getRating.test.js
@@ -1,4 +1,4 @@
-import { getRating } from "@root/observations";
+import { getRating } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the rating color", () => {

--- a/tests/observations/getScore.test.js
+++ b/tests/observations/getScore.test.js
@@ -1,4 +1,4 @@
-import { getScore } from "@root/observations";
+import { getScore } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the numeric score", () => {

--- a/tests/observations/getScoreAsText.test.js
+++ b/tests/observations/getScoreAsText.test.js
@@ -1,4 +1,4 @@
-import { getScoreAsText } from "@root/observations";
+import { getScoreAsText } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the score as string with two decimals", () => {

--- a/tests/observations/getTrend.test.js
+++ b/tests/observations/getTrend.test.js
@@ -1,4 +1,4 @@
-import { getTrend } from "@root/observations";
+import { getTrend } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the trend as a string", () => {

--- a/tests/observations/getValue.test.js
+++ b/tests/observations/getValue.test.js
@@ -1,4 +1,4 @@
-import { getValue } from "@root/observations";
+import { getValue } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the numeric value", () => {

--- a/tests/observations/getValueAsText.test.js
+++ b/tests/observations/getValueAsText.test.js
@@ -1,4 +1,4 @@
-import { getValueAsText } from "@root/observations";
+import { getValueAsText } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the value as string with two decimals", () => {

--- a/tests/observations/getYear.test.js
+++ b/tests/observations/getYear.test.js
@@ -1,4 +1,4 @@
-import { getYear } from "@root/observations";
+import { getYear } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the numeric year", () => {

--- a/tests/observations/getYearAsText.test.js
+++ b/tests/observations/getYearAsText.test.js
@@ -1,4 +1,4 @@
-import { getYearAsText } from "@root/observations";
+import { getYearAsText } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns the year as string", () => {

--- a/tests/observations/isImputed.test.js
+++ b/tests/observations/isImputed.test.js
@@ -1,4 +1,4 @@
-import { isImputed } from "@root/observations";
+import { isImputed } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("returns true if imputed", () => {

--- a/tests/observations/observationObjectToArray.test.js
+++ b/tests/observations/observationObjectToArray.test.js
@@ -1,4 +1,4 @@
-import { observationObjectToArray } from "@root/observations";
+import { observationObjectToArray } from "@sdgindex/data/observations";
 import { buildObservation } from "testHelpers/builders";
 
 it("converts observation to array", () => {

--- a/tests/parse/convertScoreToColor.test.js
+++ b/tests/parse/convertScoreToColor.test.js
@@ -1,4 +1,4 @@
-import { convertScoreToColor } from "@root/parse";
+import { convertScoreToColor } from "@sdgindex/data/parse";
 
 it("converts 2.5 to yellow", () => {
   expect(convertScoreToColor(2.5)).toEqual("yellow");

--- a/tests/parse/getIndicatorUnit.test.js
+++ b/tests/parse/getIndicatorUnit.test.js
@@ -1,4 +1,4 @@
-import { getIndicatorUnit } from "@root/parse";
+import { getIndicatorUnit } from "@sdgindex/data/parse";
 
 it("extracts '%' from label", () => {
   expect(getIndicatorUnit("this is label (%)")).toEqual("%");

--- a/tests/parse/getLabelWithoutUnit.test.js
+++ b/tests/parse/getLabelWithoutUnit.test.js
@@ -1,4 +1,4 @@
-import { getLabelWithoutUnit } from "@root/parse";
+import { getLabelWithoutUnit } from "@sdgindex/data/parse";
 
 it("returns label without '(%)'", () => {
   expect(getLabelWithoutUnit("this is label (%)")).toEqual("this is label");

--- a/tests/parse/roundNumber.test.js
+++ b/tests/parse/roundNumber.test.js
@@ -1,4 +1,4 @@
-import { roundNumber } from "@root/parse";
+import { roundNumber } from "@sdgindex/data/parse";
 
 it("rounds null to null", () => {
   expect(roundNumber(null, 3)).toEqual(null);

--- a/tests/parse/writeData.test.js
+++ b/tests/parse/writeData.test.js
@@ -1,7 +1,7 @@
 import tmp from "tmp";
 import fse from "fs-extra";
 import path from "path";
-import { writeData } from "@root/parse";
+import { writeData } from "@sdgindex/data/parse";
 
 it("creates test.json with minified JSON", () => {
   const tmpDir = tmp.dirSync().name;

--- a/tests/regions/isCountry.test.js
+++ b/tests/regions/isCountry.test.js
@@ -1,4 +1,4 @@
-import { isCountry } from "@root/regions";
+import { isCountry } from "@sdgindex/data/regions";
 import { buildRegion } from "testHelpers/builders";
 
 it("returns true if the region has type 'country'", () => {

--- a/tests/regions/isOecd.test.js
+++ b/tests/regions/isOecd.test.js
@@ -1,4 +1,4 @@
-import { isOecd } from "@root/regions";
+import { isOecd } from "@sdgindex/data/regions";
 import { buildRegion } from "testHelpers/builders";
 
 it("returns true if the region is a member of the OECD", () => {

--- a/tests/sdgs/getColor.test.js
+++ b/tests/sdgs/getColor.test.js
@@ -1,4 +1,4 @@
-import { getColor } from "@root/sdgs";
+import { getColor } from "@sdgindex/data/sdgs";
 
 it("returns #E5243B for SDG 1", () => {
   expect(getColor(1)).toEqual("#E5243B");

--- a/tests/sdgs/getLabel.test.js
+++ b/tests/sdgs/getLabel.test.js
@@ -1,4 +1,4 @@
-import { getLabel } from "@root/sdgs";
+import { getLabel } from "@sdgindex/data/sdgs";
 
 it("returns 'Good health and well-being' for SDG 3", () => {
   expect(getLabel(3)).toEqual("Good health and well-being");

--- a/tests/sdgs/getSdg.test.js
+++ b/tests/sdgs/getSdg.test.js
@@ -1,4 +1,4 @@
-import { getSdg } from "@root/sdgs";
+import { getSdg } from "@sdgindex/data/sdgs";
 
 it("returns label and color for SDG 2", () => {
   expect(getSdg(2)).toEqual({ label: "Zero hunger", color: "#DDa63a" });

--- a/tests/timeseries/getFirstYear.test.js
+++ b/tests/timeseries/getFirstYear.test.js
@@ -1,4 +1,4 @@
-import { getFirstYear } from "@root/timeseries";
+import { getFirstYear } from "@sdgindex/data/timeseries";
 import { buildTimeseries } from "testHelpers/builders";
 
 it("returns first year with non-null value", () => {

--- a/tests/timeseries/getLastYear.test.js
+++ b/tests/timeseries/getLastYear.test.js
@@ -1,4 +1,4 @@
-import { getLastYear } from "@root/timeseries";
+import { getLastYear } from "@sdgindex/data/timeseries";
 import { buildTimeseries } from "testHelpers/builders";
 
 it("returns last year with non-null value", () => {

--- a/tests/timeseries/getTimeseriesValue.test.js
+++ b/tests/timeseries/getTimeseriesValue.test.js
@@ -1,4 +1,4 @@
-import { getTimeseriesValue } from "@root/timeseries";
+import { getTimeseriesValue } from "@sdgindex/data/timeseries";
 import { buildTimeseries } from "testHelpers/builders";
 
 const timeseries = buildTimeseries({

--- a/tests/timeseries/hasTimeseries.test.js
+++ b/tests/timeseries/hasTimeseries.test.js
@@ -1,4 +1,4 @@
-import { hasTimeseries } from "@root/timeseries";
+import { hasTimeseries } from "@sdgindex/data/timeseries";
 import { buildObservation, buildTimeseries } from "testHelpers/builders";
 
 it("returns true if the object has timeseries", () => {


### PR DESCRIPTION
Jest: Set up configuration for pre-production and production tests

By running `npm test`, Jest will be run in pre-production mode and functions will be imported directly from the /src directory. This means we don't always need to run npm run build before running our tests.

Tests can also be run in production mode by running `npm run test:production`. This imports all functions from the /cjs or /es folder and requires that npm run build has been executed before.