### PR TITLE
Encode timeseries as arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "fs-extra": "^9.1.0",
         "lodash.countby": "^4.6.0",
-        "lodash.findlast": "^4.6.0",
         "lodash.get": "^4.4.2",
         "lodash.uniq": "^4.5.0",
         "url-slug": "^3.0.2",
@@ -11966,11 +11965,6 @@
       "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
       "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
       "dev": true
-    },
-    "node_modules/lodash.findlast": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.findlast/-/lodash.findlast-4.6.0.tgz",
-      "integrity": "sha1-6ou3jPLn54BPyK630ZU+B/4x+8g="
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
@@ -26255,11 +26249,6 @@
       "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
       "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
       "dev": true
-    },
-    "lodash.findlast": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.findlast/-/lodash.findlast-4.6.0.tgz",
-      "integrity": "sha1-6ou3jPLn54BPyK630ZU+B/4x+8g="
     },
     "lodash.flatten": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   "dependencies": {
     "fs-extra": "^9.1.0",
     "lodash.countby": "^4.6.0",
-    "lodash.findlast": "^4.6.0",
     "lodash.get": "^4.4.2",
     "lodash.uniq": "^4.5.0",
     "url-slug": "^3.0.2",

--- a/src/findTimeseriesByRegionAndAssessment.js
+++ b/src/findTimeseriesByRegionAndAssessment.js
@@ -5,11 +5,9 @@ import { ensureDataIds } from "./ensureDataIds";
  * Find the timeseries for a specific region and assessment.
  * @param {Object} region
  * @param {Object} assessment
- * @return {Object} return the timeseries
+ * @return {?Array} return the timeseries (or null, if none exist)
  */
 export const findTimeseriesByRegionAndAssessment = (region, assessment) => {
   ensureDataIds({ region, assessment });
-  return store.timeseries.find(
-    (series) => series.id === `${region.dataId}-${assessment.dataId}`
-  );
+  return store.timeseries[`${region.dataId}-${assessment.dataId}`] || null;
 };

--- a/src/findTimeseriesByRegionAndAssessment.js
+++ b/src/findTimeseriesByRegionAndAssessment.js
@@ -9,5 +9,9 @@ import { ensureDataIds } from "./ensureDataIds";
  */
 export const findTimeseriesByRegionAndAssessment = (region, assessment) => {
   ensureDataIds({ region, assessment });
-  return store.timeseries[`${region.dataId}-${assessment.dataId}`] || null;
+  const timeseries = store.timeseries[`${region.dataId}-${assessment.dataId}`];
+
+  if (timeseries == null) return null;
+
+  return { timeseries };
 };

--- a/src/findTimeseriesByRegionAndIndicator.js
+++ b/src/findTimeseriesByRegionAndIndicator.js
@@ -4,7 +4,7 @@ import { findTimeseriesByRegionAndAssessment } from "./findTimeseriesByRegionAnd
  * Find the timeseries for a specific region and indicator.
  * @param {Object} region
  * @param {Object} indicator
- * @return {Object} return the timeseries
+ * @return {?Array} return the timeseries (or null, if none exist)
  */
 export const findTimeseriesByRegionAndIndicator = (region, indicator) =>
   findTimeseriesByRegionAndAssessment(region, indicator);

--- a/src/parse/addTimeseries.js
+++ b/src/parse/addTimeseries.js
@@ -1,4 +1,3 @@
-import { END_YEAR, START_YEAR } from "../timeseries/config";
 import { roundNumber } from "./roundNumber";
 import { store } from "../store";
 
@@ -16,26 +15,36 @@ import { store } from "../store";
  * @return {Object} the timeseries object that was added to the store
  */
 export const addTimeseries = ({ region, assessment, dataPoints }) => {
-  // Convert dataPoints into a values array
-  const values = [];
-  for (let year = START_YEAR; year <= END_YEAR; year++) {
-    const dataPoint = dataPoints.find((point) => point.year === year);
-    const value = dataPoint ? roundNumber(dataPoint.value, 2) : null;
-    values.push(value);
-  }
+  // Filter out data points with null/undefined values
+  dataPoints = dataPoints.filter((point) => point.value != null);
 
   // If the values of all data points are null, do not add the timeseries to the
   // store.
-  if (values.every((value) => value == null)) return;
+  if (dataPoints.length === 0) return null;
 
-  const timeseries = {
-    id: `${region.dataId}-${assessment.dataId}`,
-    v: values,
-  };
+  // Identify first and last year
+  const firstYear = Math.min(...dataPoints.map((point) => point.year));
+  const lastYear = Math.max(...dataPoints.map((point) => point.year));
 
-  // Push timeseries into store
-  if (!store.timeseries) store.timeseries = [];
-  store.timeseries.push(timeseries);
+  // Format timeseries into an array, where the first element is the start year
+  // and subsequent elements are values
+  const timeseries = [firstYear];
+  for (let year = firstYear; year <= lastYear; year++) {
+    const dataPoint = dataPoints.find((point) => point.year === year);
+    const value = dataPoint ? roundNumber(dataPoint.value, 2) : null;
+    timeseries.push(value);
+  }
+
+  // Prepare timeseries in store
+  if (!store.timeseries) store.timeseries = {};
+
+  // Verify ID does not yet exist
+  const id = `${region.dataId}-${assessment.dataId}`;
+  if (Object.prototype.hasOwnProperty.call(store.timeseries, id))
+    throw new Error(`Timeseries with id ${id} already exists`);
+
+  // Add timeseries
+  store.timeseries[id] = timeseries;
 
   return timeseries;
 };

--- a/src/parse/addTimeseries.js
+++ b/src/parse/addTimeseries.js
@@ -46,5 +46,5 @@ export const addTimeseries = ({ region, assessment, dataPoints }) => {
   // Add timeseries
   store.timeseries[id] = timeseries;
 
-  return timeseries;
+  return { timeseries };
 };

--- a/src/parse/writeStoreToJson.js
+++ b/src/parse/writeStoreToJson.js
@@ -45,5 +45,5 @@ export const writeStoreToJson = () => {
     observations: encodedObservations,
     observationEncoding,
   });
-  writeDataToJson("timeseries", { timeseries: store.timeseries || [] });
+  writeDataToJson("timeseries", { timeseries: store.timeseries || {} });
 };

--- a/src/timeseries/config.js
+++ b/src/timeseries/config.js
@@ -1,9 +1,0 @@
-/**
- * @ignore
- */
-export const START_YEAR = 2000;
-
-/**
- * @ignore
- */
-export const END_YEAR = 2021;

--- a/src/timeseries/getFirstYear.js
+++ b/src/timeseries/getFirstYear.js
@@ -1,6 +1,10 @@
 /**
  * Get the first year where the timeseries has a non-null value.
  * @param {Object} timeseries
- * @returns {Number}
+ * @returns {?number}
  */
-export const getFirstYear = (timeseries) => timeseries[0];
+export const getFirstYear = ({ timeseries }) => {
+  if (timeseries == null) return null;
+
+  return timeseries[0];
+};

--- a/src/timeseries/getFirstYear.js
+++ b/src/timeseries/getFirstYear.js
@@ -1,12 +1,6 @@
-import { getTimeseriesValue } from "./getTimeseriesValue";
-import { START_YEAR, END_YEAR } from "./config";
-
 /**
  * Get the first year where the timeseries has a non-null value.
  * @param {Object} timeseries
  * @returns {Number}
  */
-export const getFirstYear = (timeseries) =>
-  Array.from({ length: END_YEAR - START_YEAR + 1 })
-    .map((_value, index) => index + START_YEAR)
-    .find((year) => getTimeseriesValue(timeseries, year) != null);
+export const getFirstYear = (timeseries) => timeseries[0];

--- a/src/timeseries/getLastYear.js
+++ b/src/timeseries/getLastYear.js
@@ -3,8 +3,11 @@ import { getFirstYear } from "./getFirstYear";
 /**
  * Get the last year where the timeseries has a non-null value.
  * @param {Object} timeseries
- * @returns {Number}
+ * @returns {?number}
  */
-export const getLastYear = (timeseries) =>
+export const getLastYear = ({ timeseries }) => {
+  if (timeseries == null) return null;
+
   // We slice the first two elements because those are start year + start value
-  getFirstYear(timeseries) + timeseries.slice(2).length;
+  return getFirstYear({ timeseries }) + timeseries.slice(2).length;
+};

--- a/src/timeseries/getLastYear.js
+++ b/src/timeseries/getLastYear.js
@@ -1,6 +1,4 @@
-import findLast from "lodash.findlast";
-import { getTimeseriesValue } from "./getTimeseriesValue";
-import { START_YEAR, END_YEAR } from "./config";
+import { getFirstYear } from "./getFirstYear";
 
 /**
  * Get the last year where the timeseries has a non-null value.
@@ -8,9 +6,5 @@ import { START_YEAR, END_YEAR } from "./config";
  * @returns {Number}
  */
 export const getLastYear = (timeseries) =>
-  findLast(
-    Array.from({ length: END_YEAR - START_YEAR + 1 }).map(
-      (_value, index) => index + START_YEAR
-    ),
-    (year) => getTimeseriesValue(timeseries, year) != null
-  );
+  // We slice the first two elements because those are start year + start value
+  getFirstYear(timeseries) + timeseries.slice(2).length;

--- a/src/timeseries/getTimeseriesValue.js
+++ b/src/timeseries/getTimeseriesValue.js
@@ -5,8 +5,11 @@ import { getFirstYear } from "./getFirstYear";
  * Get timeseries value for the given year.
  * @param {Object} timeseries
  * @param {Number} year
- * @returns {Number}
+ * @returns {?number}
  */
-export const getTimeseriesValue = (timeseries, year) =>
+export const getTimeseriesValue = ({ timeseries }, year) => {
+  if (timeseries == null) return null;
+
   // We slice the first element because that is the start year
-  get(timeseries.slice(1), year - getFirstYear(timeseries), null);
+  return get(timeseries.slice(1), year - getFirstYear({ timeseries }), null);
+};

--- a/src/timeseries/getTimeseriesValue.js
+++ b/src/timeseries/getTimeseriesValue.js
@@ -1,4 +1,5 @@
-import { START_YEAR } from "./config";
+import get from "lodash.get";
+import { getFirstYear } from "./getFirstYear";
 
 /**
  * Get timeseries value for the given year.
@@ -7,4 +8,5 @@ import { START_YEAR } from "./config";
  * @returns {Number}
  */
 export const getTimeseriesValue = (timeseries, year) =>
-  timeseries.v[year - START_YEAR];
+  // We slice the first element because that is the start year
+  get(timeseries.slice(1), year - getFirstYear(timeseries), null);

--- a/src/timeseries/hasTimeseries.js
+++ b/src/timeseries/hasTimeseries.js
@@ -3,5 +3,5 @@
  * @param {Object} timeseries
  * @returns {bool} Return true if the object has timeseries
  */
-export const hasTimeseries = (timeseries) =>
+export const hasTimeseries = ({ timeseries }) =>
   Array.isArray(timeseries) && timeseries.length > 0;

--- a/src/timeseries/hasTimeseries.js
+++ b/src/timeseries/hasTimeseries.js
@@ -4,5 +4,4 @@
  * @returns {bool} Return true if the object has timeseries
  */
 export const hasTimeseries = (timeseries) =>
-  Object.prototype.hasOwnProperty.call(timeseries, "v") &&
-  Array.isArray(timeseries.v);
+  Array.isArray(timeseries) && timeseries.length > 0;

--- a/tests/findTimeseriesByRegionAndAssessment.test.js
+++ b/tests/findTimeseriesByRegionAndAssessment.test.js
@@ -2,6 +2,7 @@ import { findTimeseriesByRegionAndAssessment } from "@sdgindex/data";
 import {
   addMockOverallAssessment,
   addMockRegion,
+  addMockIndicator,
   addMockTimeseries,
   addMockMultipleTimeseries,
 } from "testHelpers/storeMocks";
@@ -15,4 +16,14 @@ it("returns the relevant timeseries", () => {
   expect(findTimeseriesByRegionAndAssessment(region, assessment)).toEqual(
     timeseries
   );
+});
+
+describe("when the timeseries does not exist", () => {
+  it("returns null", () => {
+    const assessment = addMockIndicator();
+    const region = addMockRegion();
+    addMockMultipleTimeseries();
+
+    expect(findTimeseriesByRegionAndAssessment(region, assessment)).toBe(null);
+  });
 });

--- a/tests/findTimeseriesByRegionAndIndicator.test.js
+++ b/tests/findTimeseriesByRegionAndIndicator.test.js
@@ -16,3 +16,13 @@ it("returns the relevant timeseries", () => {
     timeseries
   );
 });
+
+describe("when the timeseries does not exist", () => {
+  it("returns null", () => {
+    const assessment = addMockIndicator();
+    const region = addMockRegion();
+    addMockMultipleTimeseries();
+
+    expect(findTimeseriesByRegionAndAssessment(region, assessment)).toBe(null);
+  });
+});

--- a/tests/getRegionsWithTimeseries.test.js
+++ b/tests/getRegionsWithTimeseries.test.js
@@ -1,4 +1,3 @@
-import { omit } from "lodash";
 import { getRegionsWithTimeseries } from "@sdgindex/data";
 import {
   addMockIndicator,
@@ -24,7 +23,5 @@ it("returns all regions", () => {
 });
 
 it("includes timeseries for each region", () => {
-  expect(getRegionsWithTimeseries(indicator)).toMatchObject(
-    timeseries.map((series) => omit(series, "id"))
-  );
+  expect(getRegionsWithTimeseries(indicator)).toMatchObject(timeseries);
 });

--- a/tests/helpers/storeMocks.js
+++ b/tests/helpers/storeMocks.js
@@ -12,7 +12,6 @@ import {
 } from "@sdgindex/data/parse";
 import { determineObjectEncoding } from "private:@sdgindex/data/utilities/determineObjectEncoding";
 import { encodeObject } from "private:@sdgindex/data/utilities/encodeObject";
-import { START_YEAR, END_YEAR } from "../../src/timeseries/config";
 import resetStore from "./resetStore";
 
 // Clear mock store before each test
@@ -116,12 +115,10 @@ export const addMockTimeseries = ({
   // Apply default values to timeseries
   timeseries = Object.assign(
     {
-      dataPoints: Array.from({ length: END_YEAR - START_YEAR + 1 }).map(
-        (_v, year) => ({
-          year: year + START_YEAR,
-          value: random(0, 1000),
-        })
-      ),
+      dataPoints: Array.from({ length: 2021 - 2000 + 1 }).map((_v, index) => ({
+        year: 2000 + index,
+        value: random(0, 1000),
+      })),
     },
     timeseries
   );

--- a/tests/parse/addTimeseries.test.js
+++ b/tests/parse/addTimeseries.test.js
@@ -41,45 +41,45 @@ it("add timeseries to the store", () => {
     ],
   });
 
-  expect(store.timeseries[0]).toEqual({
-    id: "1-35",
-    v: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2],
-  });
+  expect(store.timeseries["1-35"]).toEqual([
+    2000, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2,
+  ]);
 });
 
 it("rounds values to two decimals", () => {
   addTimeseries({
-    region: addMockRegion(),
-    assessment: addMockIndicator(),
+    region: addMockRegion({ dataId: 5 }),
+    assessment: addMockIndicator({ dataId: 37 }),
     dataPoints: [{ year: 2004, value: 115.2365 }],
   });
 
-  expect(store.timeseries[0]).toMatchObject({
-    v: [
-      null,
-      null,
-      null,
-      null,
-      115.24,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
+  expect(store.timeseries["5-37"]).toMatchObject([2004, 115.24]);
+});
+
+it("can add timeseries after 2021", () => {
+  addTimeseries({
+    region: addMockRegion({ dataId: 5 }),
+    assessment: addMockIndicator({ dataId: 37 }),
+    dataPoints: [
+      { year: 2025, value: 1 },
+      { year: 2027, value: 3 },
     ],
   });
+
+  expect(store.timeseries["5-37"]).toMatchObject([2025, 1, null, 3]);
+});
+
+it("it ignores trailing null values", () => {
+  addTimeseries({
+    region: addMockRegion({ dataId: 5 }),
+    assessment: addMockIndicator({ dataId: 37 }),
+    dataPoints: [
+      { year: 2005, value: 13 },
+      { year: 2012, value: null },
+    ],
+  });
+
+  expect(store.timeseries["5-37"]).toMatchObject([2005, 13]);
 });
 
 describe("when adding timeseries without data points", () => {

--- a/tests/parse/writeStoreToJson.test.js
+++ b/tests/parse/writeStoreToJson.test.js
@@ -40,7 +40,7 @@ it("calls writeData for assessments, regions, obs, and timeseries", () => {
       timeseries[`${region.dataId}-${assessment.dataId}`] = addMockTimeseries({
         region,
         assessment,
-      });
+      }).timeseries;
     });
   });
 

--- a/tests/parse/writeStoreToJson.test.js
+++ b/tests/parse/writeStoreToJson.test.js
@@ -28,7 +28,7 @@ it("calls writeData for assessments, regions, obs, and timeseries", () => {
   const assessments = [goal, ...addMockIndicators({ goal })];
   const regions = addMockRegions();
   const observations = {};
-  const timeseries = [];
+  const timeseries = {};
 
   assessments.forEach((assessment) => {
     regions.forEach((region) => {
@@ -37,7 +37,10 @@ it("calls writeData for assessments, regions, obs, and timeseries", () => {
           region,
           assessment,
         });
-      timeseries.push(addMockTimeseries({ region, assessment }));
+      timeseries[`${region.dataId}-${assessment.dataId}`] = addMockTimeseries({
+        region,
+        assessment,
+      });
     });
   });
 
@@ -102,7 +105,7 @@ describe("when store is empty", () => {
     );
     expect(writeJsonSync).toHaveBeenCalledWith(
       path.join(DATA_DIR, "timeseries.json"),
-      { timeseries: [] }
+      { timeseries: {} }
     );
   });
 });

--- a/tests/timeseries/getLastYear.test.js
+++ b/tests/timeseries/getLastYear.test.js
@@ -23,3 +23,11 @@ it("returns last year with non-null value", () => {
     )
   ).toEqual(2018);
 });
+
+describe("when timeseries consists of a single data point", () => {
+  it("returns last year correctly", () => {
+    expect(
+      getLastYear(addMockTimeseries({ dataPoints: [{ year: 1992, value: 3 }] }))
+    ).toEqual(1992);
+  });
+});


### PR DESCRIPTION
Instead of storing timeseries data for a specified period (e.g.,
2000-2021), we store timeseries an array where the first element is the
first year with data, the second element is the value for the first
year, and all subsequent elements are the values for the subsequent
years (e.g., third element is the value for the year after the first
year, etc...).

This allows timeseries to handle an arbitrary time period and in most
cases greatly reduces the data size.